### PR TITLE
i18n: add en.json translations for config flow and options

### DIFF
--- a/custom_components/eaton_battery_storage/translations/en.json
+++ b/custom_components/eaton_battery_storage/translations/en.json
@@ -1,0 +1,97 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Configure your Eaton xStorage Home system with technician credentials. Enable PV sensors only if you have solar panels connected to your system.",
+        "data": {
+          "host": "Device IP Address or Hostname",
+          "username": "Technician Username",
+          "password": "Technician Password",
+          "inverter_sn": "Inverter Serial Number",
+          "email": "Email Address",
+          "has_pv": "Enable PV Solar Panel Sensors (only if you have solar panels)"
+        },
+        "data_description": {
+          "has_pv": "Check this box only if you have solar panels connected to your Eaton xStorage system. This will create additional sensors for PV monitoring (voltage, current, production). Leave unchecked if you only have battery storage without solar panels."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the device. Please check your network connection and device settings.",
+      "auth": "Authentication failed. Please check your technician credentials."
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single instance is allowed."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Update your Eaton xStorage Home configuration. Changes require technician credentials verification. Enable PV sensors only if you have solar panels connected to your system.",
+        "data": {
+          "host": "Device IP Address or Hostname",
+          "username": "Technician Username",
+          "password": "Technician Password",
+          "inverter_sn": "Inverter Serial Number",
+          "email": "Email Address",
+          "has_pv": "Enable PV Solar Panel Sensors (only if you have solar panels)"
+        },
+        "data_description": {
+          "has_pv": "Check this box only if you have solar panels connected to your Eaton xStorage system. This will create additional sensors for PV monitoring (voltage, current, production). Leave unchecked if you only have battery storage without solar panels."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the device. Please check your network connection and device settings.",
+      "auth": "Authentication failed. Please check your technician credentials."
+    }
+  }
+}{
+  "config": {
+    "step": {
+      "user": {
+        "description": "Configure your Eaton xStorage Home system with technician credentials. Enable PV sensors only if you have solar panels connected to your system.",
+        "data": {
+          "host": "Device IP Address or Hostname",
+          "username": "Technician Username",
+          "password": "Technician Password",
+          "inverter_sn": "Inverter Serial Number",
+          "email": "Email Address",
+          "has_pv": "Enable PV Solar Panel Sensors (only if you have solar panels)"
+        },
+        "data_description": {
+          "has_pv": "Check this box only if you have solar panels connected to your Eaton xStorage system. This will create additional sensors for PV monitoring (voltage, current, production). Leave unchecked if you only have battery storage without solar panels."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the device. Please check your network connection and device settings.",
+      "auth": "Authentication failed. Please check your technician credentials."
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single instance is allowed."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "description": "Update your Eaton xStorage Home configuration. Changes require technician credentials verification. Enable PV sensors only if you have solar panels connected to your system.",
+        "data": {
+          "host": "Device IP Address or Hostname",
+          "username": "Technician Username",
+          "password": "Technician Password",
+          "inverter_sn": "Inverter Serial Number",
+          "email": "Email Address",
+          "has_pv": "Enable PV Solar Panel Sensors (only if you have solar panels)"
+        },
+        "data_description": {
+          "has_pv": "Check this box only if you have solar panels connected to your Eaton xStorage system. This will create additional sensors for PV monitoring (voltage, current, production). Leave unchecked if you only have battery storage without solar panels."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the device. Please check your network connection and device settings.",
+      "auth": "Authentication failed. Please check your technician credentials."
+    }
+  }
+}


### PR DESCRIPTION
Adds English translations at custom_components/eaton_battery_storage/translations/en.json.
Covers setup and options UI labels/descriptions and common errors (cannot_connect, auth, unknown).
No code changes; safe and backward-compatible.
Purpose: enable/prepare localization for the config/option flows.