### PR TITLE
Fix: Support multiple inverters via serial-scoped entries and entry-scoped entity unique_ids

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: genestealer
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
+buy_me_a_coffee: genestealer
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/custom_components/eaton_battery_storage/binary_sensor.py
+++ b/custom_components/eaton_battery_storage/binary_sensor.py
@@ -97,7 +97,8 @@ class EatonBatteryStorageBinarySensorEntity(CoordinatorEntity, BinarySensorEntit
         """Initialize the binary sensor."""
         super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"eaton_xstorage_{description.key}"
+        # Ensure unique IDs are scoped to the config entry to support multiple devices
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
 
     @property
     def is_on(self) -> bool | None:

--- a/custom_components/eaton_battery_storage/config_flow.py
+++ b/custom_components/eaton_battery_storage/config_flow.py
@@ -52,13 +52,9 @@ class EatonXStorageConfigFlow(ConfigFlow, domain=DOMAIN):
             if user_type == "tech" and not inverter_sn:
                 errors[CONF_INVERTER_SN] = "required_inverter_sn"
             else:
-                # Set unique ID (host for customer; host+sn for technician)
-                unique_id = host if user_type == "customer" else f"{host}_{inverter_sn}"
-                await self.async_set_unique_id(unique_id)
-                self._abort_if_unique_id_configured()
-
                 try:
-                    await self._test_connection(
+                    # Test connection and retrieve inverter serial if available
+                    device_serial = await self._test_connection(
                         host, username, password, inverter_sn, email, user_type
                     )
                 except ConnectionError:
@@ -83,6 +79,12 @@ class EatonXStorageConfigFlow(ConfigFlow, domain=DOMAIN):
                     _LOGGER.exception("Unexpected error during connection test")
                     errors["base"] = "unknown"
                 else:
+                    # Determine a per-device unique_id using inverter serial if present
+                    unique_suffix = device_serial or inverter_sn or username
+                    unique_id = f"{host}_{unique_suffix}" if unique_suffix else host
+                    await self.async_set_unique_id(unique_id)
+                    self._abort_if_unique_id_configured()
+
                     entry_data = dict(user_input)
                     entry_data["email"] = email
                     return self.async_create_entry(
@@ -126,8 +128,8 @@ class EatonXStorageConfigFlow(ConfigFlow, domain=DOMAIN):
         inverter_sn: str,
         email: str,
         user_type: str = "tech",
-    ) -> None:
-        """Test connection to the device."""
+    ) -> str | None:
+        """Test connection to the device and return inverter serial if available."""
         api = EatonBatteryAPI(
             hass=self.hass,
             host=host,
@@ -143,6 +145,22 @@ class EatonXStorageConfigFlow(ConfigFlow, domain=DOMAIN):
 
         try:
             await api.connect()
+            # Attempt to read device information to extract serial number
+            try:
+                device_resp = await api.get_device()
+                device_data = (
+                    device_resp.get("result", {})
+                    if isinstance(device_resp, dict)
+                    else device_resp
+                )
+                serial = (
+                    device_data.get("inverterSerialNumber")
+                    if isinstance(device_data, dict)
+                    else None
+                )
+            except Exception:  # best-effort; serial not strictly required
+                serial = None
+            return serial
         except ValueError as err:
             _LOGGER.warning("Authentication failed: %s", err)
             raise ValueError("Invalid credentials") from err
@@ -275,8 +293,8 @@ class EatonXStorageOptionsFlow(OptionsFlow):
         inverter_sn: str,
         email: str,
         user_type: str = "tech",
-    ) -> None:
-        """Test connection to the device."""
+    ) -> str | None:
+        """Test connection to the device and return inverter serial if available."""
         api = EatonBatteryAPI(
             hass=self.hass,
             host=host,
@@ -292,6 +310,22 @@ class EatonXStorageOptionsFlow(OptionsFlow):
 
         try:
             await api.connect()
+            # Try to fetch the device serial to allow per-device unique_id
+            try:
+                device_resp = await api.get_device()
+                device_data = (
+                    device_resp.get("result", {})
+                    if isinstance(device_resp, dict)
+                    else device_resp
+                )
+                serial = (
+                    device_data.get("inverterSerialNumber")
+                    if isinstance(device_data, dict)
+                    else None
+                )
+            except Exception:
+                serial = None
+            return serial
         except ValueError as err:
             _LOGGER.warning("Authentication failed: %s", err)
             raise ValueError("Invalid credentials") from err

--- a/custom_components/eaton_battery_storage/config_flow.py
+++ b/custom_components/eaton_battery_storage/config_flow.py
@@ -158,9 +158,11 @@ class EatonXStorageConfigFlow(ConfigFlow, domain=DOMAIN):
                     if isinstance(device_data, dict)
                     else None
                 )
-            except Exception:  # best-effort; serial not strictly required
-                serial = None
-            return serial
+            except Exception as exc:  # best-effort; serial not strictly required  
+                _LOGGER.debug(  
+                    "Failed to retrieve device serial number: %s",  
+                    exc,  
+                )  
         except ValueError as err:
             _LOGGER.warning("Authentication failed: %s", err)
             raise ValueError("Invalid credentials") from err
@@ -323,7 +325,8 @@ class EatonXStorageOptionsFlow(OptionsFlow):
                     if isinstance(device_data, dict)
                     else None
                 )
-            except Exception:
+            except Exception as exc:  
+                _LOGGER.debug("Failed to retrieve device serial number: %s", exc)  
                 serial = None
             return serial
         except ValueError as err:

--- a/custom_components/eaton_battery_storage/manifest.json
+++ b/custom_components/eaton_battery_storage/manifest.json
@@ -16,5 +16,5 @@
   ],
   "quality_scale": "bronze",
   "requirements": [],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/custom_components/eaton_battery_storage/number.py
+++ b/custom_components/eaton_battery_storage/number.py
@@ -109,7 +109,10 @@ class EatonBatteryNumberEntity(CoordinatorEntity, NumberEntity):
         """Initialize the entity."""
         super().__init__(coordinator)
         self._key = description["key"]
-        self._attr_unique_id = f"eaton_battery_{description['key']}"
+        # Scope unique ID to config entry to support multiple devices
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{description['key']}"
+        )
         self._attr_name = description["name"]
         self._attr_native_min_value = float(description["min"])
         self._attr_native_max_value = float(description["max"])
@@ -225,7 +228,10 @@ class EatonXStorageHouseConsumptionThresholdNumber(CoordinatorEntity, NumberEnti
     def __init__(self, coordinator: EatonBatteryStorageCoordinator) -> None:
         """Initialize the house consumption threshold number entity."""
         super().__init__(coordinator)
-        self._attr_unique_id = "eaton_xstorage_set_house_consumption_threshold"
+        # Scope unique ID to config entry for multi-device setups
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_set_house_consumption_threshold"
+        )
         self._attr_name = "House consumption threshold"
         self._optimistic_value: int | None = None
 
@@ -371,7 +377,10 @@ class EatonXStorageBatteryBackupLevelNumber(CoordinatorEntity, NumberEntity):
     def __init__(self, coordinator: EatonBatteryStorageCoordinator) -> None:
         """Initialize the battery backup level number entity."""
         super().__init__(coordinator)
-        self._attr_unique_id = "eaton_xstorage_set_battery_backup_level"
+        # Scope unique ID to config entry for multi-device setups
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_set_battery_backup_level"
+        )
         self._attr_name = "Battery backup level"
         self._optimistic_value: int | None = None
 

--- a/custom_components/eaton_battery_storage/sensor.py
+++ b/custom_components/eaton_battery_storage/sensor.py
@@ -731,11 +731,13 @@ class EatonXStorageNotificationsSensor(
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = "Notifications"
-    _attr_unique_id = "eaton_xstorage_notifications"
+    # Scope unique ID to config entry for multi-device support
+    _attr_unique_id = None
 
     def __init__(self, coordinator: EatonXstorageHomeCoordinator) -> None:
         """Initialize the notifications sensor."""
         super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_notifications"
 
     @property
     def native_value(self) -> int:
@@ -813,7 +815,10 @@ class EatonXStorageSensor(
         )
         self._accuracy_warning = description.get("accuracy_warning", False)
         self._precision = description.get("precision")
-        self._attr_unique_id = f"eaton_xstorage_{key.replace('.', '_')}"
+        # Ensure per-entry unique IDs to avoid collisions across multiple devices
+        self._attr_unique_id = (
+            f"{coordinator.config_entry.entry_id}_{key.replace('.', '_')}"
+        )
 
         # Apply icon from description if provided
         if description.get("icon"):

--- a/custom_components/eaton_battery_storage/switch.py
+++ b/custom_components/eaton_battery_storage/switch.py
@@ -46,7 +46,8 @@ class EatonXStoragePowerSwitch(CoordinatorEntity, SwitchEntity):
     def __init__(self, coordinator: EatonBatteryStorageCoordinator) -> None:
         """Initialize the power switch."""
         super().__init__(coordinator)
-        self._attr_unique_id = "eaton_xstorage_inverter_power"
+        # Scope unique ID to the config entry for multi-device setups
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_inverter_power"
         self._attr_name = "Inverter power"
         self._optimistic_state: bool | None = None
 
@@ -160,7 +161,8 @@ class EatonXStorageEnergySavingModeSwitch(CoordinatorEntity, SwitchEntity):
     def __init__(self, coordinator: EatonBatteryStorageCoordinator) -> None:
         """Initialize the energy saving mode switch."""
         super().__init__(coordinator)
-        self._attr_unique_id = "eaton_xstorage_energy_saving_mode"
+        # Scope unique ID to the config entry for multi-device setups
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}_energy_saving_mode"
         self._attr_name = "Energy saving mode"
         self._optimistic_state: bool | None = None
 


### PR DESCRIPTION
This pull request improves support for multiple Eaton battery storage devices in a single Home Assistant instance by ensuring all entity and config entry unique IDs are properly scoped per device. It also enhances the config flow to reliably generate unique IDs based on the inverter serial number when available.

fix: support multiple inverters via serial-scoped entries and entry-scoped entity unique_ids
- Root cause: static entity unique_ids and host-only config entry unique_id caused
  collisions and “already_configured” when adding a second inverter.
- Config flow: after successful connect, derive unique_id as host_<inverterSerialNumber>;
  fallback to provided SN/username if serial unavailable.
- Entities: include config_entry.entry_id in unique_id across sensor, binary_sensor,
  switch, and number platforms to prevent cross-device collisions.

Effect:
- Multiple inverters (even sharing the same IP during testing) can be added;
  each device registers a full, distinct entity set.

Migration notes:
- Existing entries continue to work; new entries use serial-based unique_id.
- Some entities may get new registry entries due to unique_id changes; re-linking
  in dashboards/automations may be needed if HA recreates them.

Closes https://github.com/greyfold/home_assistant_eaton_battery_storage/issues/24

**Unique ID scoping for multi-device support:**

* All entities in `binary_sensor.py`, `number.py`, `sensor.py`, and `switch.py` now generate their `_attr_unique_id` using the `config_entry.entry_id`, ensuring uniqueness across multiple devices and preventing entity ID collisions. [[1]](diffhunk://#diff-34f978cd14659477d7559c20d46efbfb184d023343ba47e8fa2762fe853eb68bL100-R101) [[2]](diffhunk://#diff-04685c19f601f294b5b8de46cf2a7d2dffb864b141da5369f37590e2cd8686b9L112-R115) [[3]](diffhunk://#diff-04685c19f601f294b5b8de46cf2a7d2dffb864b141da5369f37590e2cd8686b9L228-R234) [[4]](diffhunk://#diff-04685c19f601f294b5b8de46cf2a7d2dffb864b141da5369f37590e2cd8686b9L374-R383) [[5]](diffhunk://#diff-526636a50dedd94da45d399b81a44d432f2618996b6c8ce03680f71d8e0c2402L734-R740) [[6]](diffhunk://#diff-526636a50dedd94da45d399b81a44d432f2618996b6c8ce03680f71d8e0c2402L816-R821) [[7]](diffhunk://#diff-2d38e4ab4972b821a70c1b0a4c82f026cd8d024a2f55176d816a9ccc211c3683L49-R50) [[8]](diffhunk://#diff-2d38e4ab4972b821a70c1b0a4c82f026cd8d024a2f55176d816a9ccc211c3683L163-R165)

**Config flow improvements:**

* The config flow (`config_flow.py`) now tests the connection to fetch the inverter serial number if available, and uses it to generate a per-device unique ID for the config entry. This prevents duplicate configuration and ensures each device is uniquely identified. [[1]](diffhunk://#diff-cfd29a567bc29aa60caf7d6d066f00092a3d9093617ed99c599d491615f2dc31L55-R57) [[2]](diffhunk://#diff-cfd29a567bc29aa60caf7d6d066f00092a3d9093617ed99c599d491615f2dc31R82-R87) [[3]](diffhunk://#diff-cfd29a567bc29aa60caf7d6d066f00092a3d9093617ed99c599d491615f2dc31L129-R132) [[4]](diffhunk://#diff-cfd29a567bc29aa60caf7d6d066f00092a3d9093617ed99c599d491615f2dc31R148-R163) [[5]](diffhunk://#diff-cfd29a567bc29aa60caf7d6d066f00092a3d9093617ed99c599d491615f2dc31L278-R297) [[6]](diffhunk://#diff-cfd29a567bc29aa60caf7d6d066f00092a3d9093617ed99c599d491615f2dc31R313-R328)